### PR TITLE
Add Python 3.6 to the testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
 # setup environment
 before_install:
   - virtualenv venv


### PR DESCRIPTION
Python 3.6 is now available in the Bluemix buildpack for Python
https://console.bluemix.net/docs/runtimes/python/index.html#python_runtime